### PR TITLE
Include functionality to display two different background colors

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,3 +36,11 @@ div {
     background-color: #cbeed7;
     border-radius: 10px;    
 }
+
+.odd {
+    background-color: lightblue;
+}
+
+.even {
+    background-color: lightcoral;
+}

--- a/templates/booking_lists/index.html
+++ b/templates/booking_lists/index.html
@@ -3,10 +3,21 @@
 
 <h2>Booking list</h2>
 
+{% set counter = namespace(element = 2) %}
+
 {% for booking_list in booking_lists %}
 
+    {% if counter.element is divisibleby 2 %}
+        {% set dynamic_class = "even" %}
+    {% else %}
+        {% set dynamic_class = "odd" %}
+    {% endif %}
+
+    {% set counter.element = counter.element + 1 %}
+
+
 <section>
-    <div class="container">
+    <div class="container {{ dynamic_class }}">
         <h4>Member:{{ booking_list.member.name }}, Sport class:{{ booking_list.sport_class.name }}</h5>
         <a href="/booking_lists/{{ booking_list.id }}/edit">Edit</a>
         <form action="/booking_lists/{{ booking_list.id }}"></form>

--- a/templates/members/index.html
+++ b/templates/members/index.html
@@ -3,11 +3,20 @@
 
 <h2>Members</h2>
 
+{% set counter = namespace(element = 2) %}
 
 {% for member in members %}
 
+    {% if counter.element is divisibleby 2 %}
+        {% set dynamic_class = "even" %}
+    {% else %}
+        {% set dynamic_class = "odd" %}
+    {% endif %}
+
+    {% set counter.element = counter.element + 1 %}
+
 <section>
-    <div class="container">
+    <div class="container {{ dynamic_class }}">
         <h3>{{ member.name }}</h3>
         <h5>Age:{{member.age}}, Address:{{member.address}}, Phone number:{{member.phone_number}}</h5>
         <a href="/members/{{ member.id }}/edit">Edit</a>

--- a/templates/sport_classes/index.html
+++ b/templates/sport_classes/index.html
@@ -3,10 +3,20 @@
 
 <h2>Sport classes</h2>
 
+{% set counter = namespace(element = 2) %}
+
 {% for sport_class in sport_classes %}
 
+    {% if counter.element is divisibleby 2 %}
+         {% set dynamic_class = "even" %}
+    {% else %}
+          {% set dynamic_class = "odd" %}
+    {% endif %}
+
+    {% set counter.element = counter.element + 1 %}
+
 <section>
-    <div class="container">
+    <div class="container {{ dynamic_class }}">
         <h3>{{ sport_class.name }}</h3>
         <h5>Date:{{sport_class.date}}, Duration:{{sport_class.duration}}, Capacity:{{sport_class.capacity}}</h5>
         <a href="/sport_classes/{{ sport_class.id }}/edit">Edit</a>


### PR DESCRIPTION
This pull request adds the functionality to be able to display alternative background colors in the **index** page of _booking_lists_, _members_ and _sport_classes_.

This was achieved using a simple for loop with an if/else statement, but implemented as per Jinja2 requirements.